### PR TITLE
feat: update dependencies and improve configuration paths

### DIFF
--- a/MISSION_CONTROL/.chezmoidata/homebrew.yaml
+++ b/MISSION_CONTROL/.chezmoidata/homebrew.yaml
@@ -96,7 +96,9 @@ homebrew:
       - brew-cask-completion
       - btop
       - bundler-completion
+      - carapace
       - chezmoi
+      - cmake
       - cmake-docs
       - cspell
       - colordiff

--- a/MISSION_CONTROL/.chezmoidata/mise.yaml
+++ b/MISSION_CONTROL/.chezmoidata/mise.yaml
@@ -70,8 +70,6 @@ mise:
   dev_tools:
     - name: act
       version: latest
-    - name: cmake
-      version: latest
     - name: fastfetch
       version: latest
     - name: gitleaks

--- a/MISSION_CONTROL/dot_config/nvim/.lazyextras/lazyvim.json
+++ b/MISSION_CONTROL/dot_config/nvim/.lazyextras/lazyvim.json
@@ -39,6 +39,8 @@
     "lazyvim.plugins.extras.lang.nix",
     "lazyvim.plugins.extras.lang.nushell",
     "lazyvim.plugins.extras.lang.ocaml",
+    "lazyvim.plugins.extras.lang.omnisharp",
+    "lazyvim.plugins.extras.lang.php",
     "lazyvim.plugins.extras.lang.python",
     "lazyvim.plugins.extras.lang.ruby",
     "lazyvim.plugins.extras.lang.rust",

--- a/MISSION_CONTROL/dot_config/nvim/symlink_lazyvim.json.tmpl
+++ b/MISSION_CONTROL/dot_config/nvim/symlink_lazyvim.json.tmpl
@@ -1,1 +1,1 @@
-{{ .chezmoi.sourceDir }}/../nvim/lazyvim.json
+{{ .chezmoi.sourceDir }}/dot_config/nvim/.lazyextras/lazyvim.json


### PR DESCRIPTION
- Added `carapace` and `cmake` to Homebrew dependencies.
- Removed `cmake` from `mise` dev_tools to avoid duplication.
- Renamed and moved `lazyvim.json` to `.lazyextras` directory.
- Updated symlink template to reflect the new `lazyvim.json` path.
- Included PHP language support in LazyVim configuration.

## Description

Brief description of the changes.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] Configuration change
- [ ] Breaking change