### PR TITLE
fix(nvim): resolve blame.nvim configuration error

### DIFF
--- a/MISSION_CONTROL/dot_config/nvim/lua/plugins/dev/blame.lua
+++ b/MISSION_CONTROL/dot_config/nvim/lua/plugins/dev/blame.lua
@@ -9,11 +9,6 @@ return {
     opts = {
       date_format = "%d.%m.%Y",
       virtual_style = "float",
-      views = {
-        default = "virtual",
-        virtual = "virtual",
-        window = "window",
-      },
       merge_consecutive = true,
       max_summary_width = 30,
       commit_detail_view = "vsplit",
@@ -25,5 +20,8 @@ return {
         close = { "<esc>", "q" },
       },
     },
+    config = function(_, opts)
+      require("blame").setup(opts)
+    end,
   },
 }


### PR DESCRIPTION
## Summary
- Remove problematic views table override that was causing startup error
- Plugin now uses its default view configuration properly
- Fixes "attempt to call method 'new' (a nil value)" error at lua/blame.lua:88

## Test plan
- [x] Neovim starts without errors
- [ ] `<leader>gb` keybinding opens blame view correctly
- [ ] Blame window displays git blame information properly

🤖 Generated with [Claude Code](https://claude.ai/code)