### PR TITLE
fix(nushell): add hasKey check for ai section in template

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,8 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(chezmoi:*)"
+    ],
+    "deny": []
+  }
+}

--- a/MISSION_CONTROL/dot_config/nushell/env.nu.tmpl
+++ b/MISSION_CONTROL/dot_config/nushell/env.nu.tmpl
@@ -133,4 +133,8 @@ $env.GOOGLE_CLOUD_PROJECT = "{{ .work.google_cloud_project }}"
 {{ end }}
 
 ## AI - LLM
+{{ if hasKey . "ai" -}}
+{{ if ne .ai.gemini_api_key "replace_with_gemini_api_key" -}}
 $env.GEMINI_API_KEY = "{{ .ai.gemini_api_key }}"
+{{ end -}}
+{{ end -}}


### PR DESCRIPTION
## Summary
• Fix template execution error when ai section is missing from chezmoi configuration
• Add conditional hasKey check to prevent "map has no entry for key 'ai'" error
• Ensures nushell environment template only sets GEMINI_API_KEY when ai section exists

## Test plan
- [x] Template compiles without error when ai section is missing
- [x] Template still works when ai section is present
- [x] chezmoi apply runs successfully
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.ai/code)