### PR TITLE
fix(ghostty): update nushell get command to use --optional flag

### DIFF
--- a/MISSION_CONTROL/dot_config/ghostty/executable_ghostty-init.nu
+++ b/MISSION_CONTROL/dot_config/ghostty/executable_ghostty-init.nu
@@ -2,7 +2,7 @@
 
 source ~/.config/nushell/env.nu
 
-if ($env | get -i TMUX | is-empty ) {
+if ($env | get --optional TMUX | is-empty ) {
   exec "/opt/homebrew/bin/tmux" new-session -A -s "ghostty"
 } else {
   /opt/homebrew/bin/nu


### PR DESCRIPTION
Replace deprecated -i flag with --optional for better compatibility with newer Nushell versions.

🤖 Generated with [opencode](https://opencode.ai)

## Description

Brief description of the changes.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Configuration change
- [ ] Breaking change

## Checklist

- [ ] I have tested my changes locally.
- [ ] I have updated documentation as needed.
- [ ] I have added tests as needed.
- [ ] I have added a descriptive commit message.

## Screenshots (if applicable)

```text
# Add screenshots or GIFs here
```
