### PR TITLE
Update package configurations and improve installation output

### DIFF
--- a/MISSION_CONTROL/.chezmoidata/homebrew/mas.yaml
+++ b/MISSION_CONTROL/.chezmoidata/homebrew/mas.yaml
@@ -1,3 +1,3 @@
 mas:
-  - '"Dynamic wallpaper", id: 1582358382'
-  - '"FileZilla Pro", id: 1298486723'
+  - '\"Dynamic wallpaper\", id: 1582358382'
+  - '\"FileZilla Pro\", id: 1298486723'

--- a/MISSION_CONTROL/.chezmoidata/mise/node.yaml
+++ b/MISSION_CONTROL/.chezmoidata/mise/node.yaml
@@ -36,4 +36,5 @@ nodejs:
     - name: "mcp-neovim-server"
       description: "MCP server for Neovim integration"
     - name: vercel
+      version: "44.5.5"
       description: "Vercel CLI tool"

--- a/MISSION_CONTROL/dot_rustup/run_once_after_settings.sh.tmpl
+++ b/MISSION_CONTROL/dot_rustup/run_once_after_settings.sh.tmpl
@@ -18,9 +18,9 @@ if [ "$RUST_INSTALLED" != "true" ]; then
   
   {{ if env "CODESPACES" -}}
   # Use minimal profile for Codespaces to save space
-  curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable --profile minimal --no-modify-path
+  curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable --profile minimal --no-modify-path >/dev/null 2>&1
   {{ else -}}
-  curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain nightly --profile default --no-modify-path
+  curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain nightly --profile default --no-modify-path >/dev/null 2>&1
   {{ end -}}
   
   echo "🔵 Rust toolchain installed/updated via rustup."


### PR DESCRIPTION
## Summary
• Fix YAML quote escaping in homebrew mas configuration for better compliance
• Pin Vercel CLI version (44.5.5) to ensure reproducible installations
• Silence Rust installation output to reduce log verbosity during setup

## Test plan
- [ ] Verify mas.yaml parses correctly with fixed quote escaping
- [ ] Confirm Vercel CLI installs at specified version 44.5.5
- [ ] Test Rust installation runs silently while still completing successfully
- [ ] Run chezmoi apply to ensure all changes work as expected

🤖 Generated with [opencode](https://opencode.ai)