### PR TITLE
Remove unused artifact upload from nvim test workflow

### DIFF
--- a/.github/workflows/test-nvim.yml
+++ b/.github/workflows/test-nvim.yml
@@ -36,10 +36,3 @@ jobs:
         run: |
           cd _tests_
           go test -v ./unit -run TestNvim
-
-      - name: Upload test results
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: test-results
-          path: _tests_/test-results/


### PR DESCRIPTION
The workflow was trying to upload test results from _tests_/test-results/ but Go tests don't generate files in that directory by default, causing CI warnings about missing artifacts.

🤖 Generated with [opencode](https://opencode.ai)

## Description

Brief description of the changes.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Configuration change
- [ ] Breaking change

## Checklist

- [ ] I have tested my changes locally.
- [ ] I have updated documentation as needed.
- [ ] I have added tests as needed.
- [ ] I have added a descriptive commit message.

## Screenshots (if applicable)

```text
# Add screenshots or GIFs here
```
