### PR TITLE
Fix hardcoded user paths with Chezmoi homedir templates

### DIFF
--- a/.chezmoidata/mise/packages/tools.yaml
+++ b/.chezmoidata/mise/packages/tools.yaml
@@ -39,17 +39,6 @@ tools:
       description: "Command-line benchmarking tool"
 
   # =============================================================================
-  # TERMINAL & SHELL TOOLS - Terminal multiplexers, prompts, navigation, editors
-  # =============================================================================
-  terminal_tools:
-    - name: starship
-      version: latest
-      description: "Cross-shell prompt"
-    - name: zoxide
-      version: latest
-      description: "Smart cd command"
-
-  # =============================================================================
   # DOCUMENTATION & PRESENTATION - Documentation generation and presentation
   # =============================================================================
   docs_tools:

--- a/.chezmoidata/packages/macos/brews.yaml
+++ b/.chezmoidata/packages/macos/brews.yaml
@@ -47,7 +47,6 @@ brews:
     - findutils
     - fish
     - fish-lsp
-    # - fnm
     - fzf
     - gawk
     - gcc@11
@@ -119,6 +118,7 @@ brews:
     - sevenzip
     - sd
     - sk
+    - starship
     - tflint
     - thefuck
     - tig
@@ -137,6 +137,7 @@ brews:
     - yamllint
     - yaml-language-server
     - yazi
+    - zoxide
     - yq
     - zls
     - zsh

--- a/.chezmoidata/packages/macos/brews.yaml
+++ b/.chezmoidata/packages/macos/brews.yaml
@@ -137,9 +137,9 @@ brews:
     - yamllint
     - yaml-language-server
     - yazi
-    - zoxide
     - yq
     - zls
+    - zoxide
     - zsh
     - zsh-completions
     - zsh-autosuggestions

--- a/dot_local/share/nushell/vendor/autoload/mise_activate.nu.tmpl
+++ b/dot_local/share/nushell/vendor/autoload/mise_activate.nu.tmpl
@@ -1,4 +1,4 @@
-$env.PATH = r#'/usr/local/bin:/Library/Developer/CommandLineTools/usr/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/opt/homebrew/opt/libpq/bin:/opt/homebrew/opt/unzip/bin:/opt/homebrew/opt/gnu-sed/libexec/gnubin:/Users/beanie/.cargo/bin:/Users/beanie/.local/bin:/bin:/usr/bin:/usr/sbin:/sbin:/Applications/Ghostty.app/Contents/MacOS'#
+$env.PATH = r#'/usr/local/bin:/Library/Developer/CommandLineTools/usr/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/opt/homebrew/opt/libpq/bin:/opt/homebrew/opt/unzip/bin:/opt/homebrew/opt/gnu-sed/libexec/gnubin:{{ .chezmoi.homeDir }}/.cargo/bin:{{ .chezmoi.homeDir }}/.local/bin:/bin:/usr/bin:/usr/sbin:/sbin:/Applications/Ghostty.app/Contents/MacOS'#
 export-env {
   $env.MISE_SHELL = "nu"
   let mise_hook = {
@@ -24,15 +24,14 @@ export def --env --wrapped main [command?: string, --help, ...rest: string] {
   let commands = ["deactivate", "shell", "sh"]
 
   if ($command == null) {
-    ^"/Users/beanie/.local/bin/mise"
-  } else if ($command == "activate") {
+    ^"{{ .chezmoi.homeDir }}/.local/bin/mise"  } else if ($command == "activate") {
     $env.MISE_SHELL = "nu"
   } else if ($command in $commands) {
-    ^"/Users/beanie/.local/bin/mise" $command ...$rest
+    ^"{{ .chezmoi.homeDir }}/.local/bin/mise" $command ...$rest
     | parse vars
     | update-env
   } else {
-    ^"/Users/beanie/.local/bin/mise" $command ...$rest
+    ^"{{ .chezmoi.homeDir }}/.local/bin/mise" $command ...$rest
   }
 }
 
@@ -51,7 +50,7 @@ def --env "update-env" [] {
 }
 
 def --env mise_hook [] {
-  ^"/Users/beanie/.local/bin/mise" hook-env -s nu
+  ^"{{ .chezmoi.homeDir }}/.local/bin/mise" hook-env -s nu
     | parse vars
     | update-env
 }


### PR DESCRIPTION
## Summary
- Fixes cross-user compatibility by converting hardcoded user paths to Chezmoi homedir templates
- Reorganizes package management for better consistency between mise and homebrew

## Test plan
- [ ] Apply dotfiles on a different user account to verify paths resolve correctly
- [ ] Verify mise activation works in nushell after template conversion
- [ ] Confirm starship prompt loads properly with PATH-based resolution

🤖 Generated with [opencode](https://opencode.ai)