### PR TITLE
Fix template boolean comparison causing nushell startup errors

### DIFF
--- a/.chezmoitemplates/platform-storage-env.tmpl
+++ b/.chezmoitemplates/platform-storage-env.tmpl
@@ -9,7 +9,7 @@
 ##
 ## PLATFORM STORAGE ENVIRONMENT VARIABLES
 ##
-{{ if and (eq .context.chezmoi.os "darwin") (or (not (hasKey .context "WORK_ENVIRONMENT")) (eq .context.WORK_ENVIRONMENT true) (eq .context.WORK_ENVIRONMENT "true")) -}}
+{{ if and (eq .context.chezmoi.os "darwin") (or (not (hasKey .context "WORK_ENVIRONMENT")) .context.WORK_ENVIRONMENT) -}}
 {{- $platformJson := (output "sh" "-c" "defaults export com.chezmoi.env - 2>/dev/null | plutil -convert json -o - - 2>/dev/null || echo '{}'") }}
 {{- $platformVars := (fromJson $platformJson) }}
 {{- range $key, $value := $platformVars }}


### PR DESCRIPTION
## Summary
• Fix boolean comparison logic in platform-storage-env template that was causing chezmoi template execution to fail
• Resolves nushell startup errors by simplifying WORK_ENVIRONMENT boolean evaluation

## Test plan
- [x] Verify template renders without errors: `chezmoi apply`
- [x] Confirm nushell starts successfully: `nu -c "echo 'success'"`
- [x] Check platform-storage-env.nu file is properly generated
- [x] Validate no regression in environment variable handling

🤖 Generated with [opencode](https://opencode.ai)