### PR TITLE
fix: Implement lazy loading for nvim language-config template

### DIFF
--- a/dot_config/nvim/lua/utils/language-config.lua.tmpl
+++ b/dot_config/nvim/lua/utils/language-config.lua.tmpl
@@ -1,8 +1,8 @@
-{{- $parsers_data := fromJson .parsers_yaml.content }}
-{{- $lsp_data := fromJson .lsp_yaml.content }}
-{{- $formatters_data := fromJson .formatters_yaml.content }}
-{{- $linters_data := fromJson .linters_yaml.content }}
-{{- $tools_data := fromJson .tools_yaml.content }}
+{{- $parsers_data := (include (printf "%s/.chezmoidata/parsers.yaml" .chezmoi.sourceDir) | fromYaml) }}
+{{- $lsp_data := (include (printf "%s/.chezmoidata/lsp.yaml" .chezmoi.sourceDir) | fromYaml) }}
+{{- $formatters_data := (include (printf "%s/.chezmoidata/formatters.yaml" .chezmoi.sourceDir) | fromYaml) }}
+{{- $linters_data := (include (printf "%s/.chezmoidata/linters.yaml" .chezmoi.sourceDir) | fromYaml) }}
+{{- $tools_data := (include (printf "%s/.chezmoidata/tools.yaml" .chezmoi.sourceDir) | fromYaml) }}
 
 return {
   treesitter = {


### PR DESCRIPTION
- Convert language-config.lua.tmpl to use lazy loading pattern
- Load YAML files directly in template instead of via .chezmoi.toml.tmpl
- Fix buffer-specific diagnostic disabling in markdown autocmd
- Resolves template execution error after YAML loading removal